### PR TITLE
fix links

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@
 [0to255](https://www.0to255.com)  
 [Adobe Color](https://color.adobe.com/pt/create/color-wheel)    
 [Brand Palettes](https://brandpalettes.com)  
-⁣[calcolor.co⁣](calcolor.co⁣)  
+⁣[calcolor.co⁣](https://calcolor.co/⁣)  
 [Color Hunt](https://colorhunt.co)  
 [Color.review](https://color.review)     
 [Colorfavs](http://www.colorfavs.com)  
@@ -172,7 +172,7 @@
 [JSchallenger](https://www.jschallenger.com/)  
 [WoMakersCode Front-end Challenges](https://github.com/WoMakersCode/challenges-front-end)  
 ## INSPIRAÇÕES
-[Awwwards](awwwards.com)  
+[Awwwards](https://www.awwwards.com/) 
 [CollectUI](https://collectui.com)  
 [Dribbble](https://dribbble.com)  
 [Httpster](https://httpster.net/2020/apr/)  


### PR DESCRIPTION
Havia dos links que estavam sem o HTTPS. Por causa disso ao clicar neles não éramos direcionados aos sites.

![url direcionada](https://user-images.githubusercontent.com/45303056/103412936-457ca780-4b56-11eb-953a-9d1c82bfae9e.PNG)
![arquivo fonte](https://user-images.githubusercontent.com/45303056/103412938-46add480-4b56-11eb-8bdd-7cc42cbfe459.PNG)

